### PR TITLE
feat: add support for str cids to ease testing

### DIFF
--- a/ipld_car/__init__.py
+++ b/ipld_car/__init__.py
@@ -13,7 +13,7 @@ Block = Tuple[CID, BytesLike]
 """ Represents an IPLD block (including its CID). """
 
 
-def encode(roots: list[CID], blocks: list[Block]) -> memoryview:
+def encode(roots: list[CID | str], blocks: list[Block]) -> memoryview:
     """
     Encode a CAR v1 file from a list of root CIDs and blocks.
     """
@@ -26,8 +26,10 @@ def encode(roots: list[CID], blocks: list[Block]) -> memoryview:
 
     for b in blocks:
         cid = b[0]
-        if not isinstance(cid, CID):
-            raise TypeError("block CID is not an instance of CID")
+        if not (isinstance(cid, CID) or isinstance(cid, str)):
+            raise TypeError("block CID is not an instance of CID or string")
+        if isinstance(cid, str):
+            cid = CID.decode(cid)
         cid_bytes = bytes(cid)
 
         block_bytes = b[1]


### PR DESCRIPTION
I'm adding support for base64 string CIDs to make sorting blocks containing these stringified CIDs easier.

See PR here: https://github.com/ipld/codec-fixtures/pull/152 for more details.