### PR TITLE
Packaging cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,10 @@
+# SPDX-FileCopyrightText: 2025 Contributers to py-ipld-car <https://github.com/storacha/py-ipld-car>
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+__pycache__
+.mypy_cache
+.pytest_cache
+*.egg-info
+*.py[cdoz]
+build
 dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,10 @@ classifiers = [
 ]
 license = "Apache-2.0 OR MIT"
 license-files = ["LICENSE.md"]
+dependencies = [
+    "dag-cbor>=0.3.3",
+    "multiformats>=0.3.1.post4",
+]
 
 [project.urls]
 Homepage = "https://github.com/storacha/py-ipld-car"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,11 @@ requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 license = "Apache-2.0 OR MIT"
 license-files = ["LICENSE.md"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 bases==0.3.0
-dag-cbor==0.3.3
-multiformats==0.3.1.post4
 multiformats-config==0.3.1
 typing-validation==1.2.11.post4
 typing_extensions==4.12.2

--- a/test/test_ipld_car.py
+++ b/test/test_ipld_car.py
@@ -1,4 +1,6 @@
-import pytest
+# SPDX-FileCopyrightText: 2025 Contributers to py-ipld-car <https://github.com/storacha/py-ipld-car>
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
 from multiformats import multihash, CID
 import ipld_car
 from ipld_car import Block


### PR DESCRIPTION
Without the `project.dependencies` entry py-ipld-car suffers `ImportError` exceptions when installed using just `pip install py-ipld-car`. I changed the versions to minimums because this is recommended best practice (by PyPA and others) for library dependencies [^1].

I left the other requirements.txt entries alone. I can't spot their purpose, so Chesterton's Fence principal applies.

[^1]: https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements/